### PR TITLE
Fix bug and remove the necessity of double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ To show a random pokemon, simply run:
 $HOME/.pokemon-icat/pokemon-icat.sh
 ```
 
-If you want to specify one or more generations in particular, simply add `"--gen [numbers]"` at the end, **between quotes**, for example:
+If you want to specify one or more generations in particular, simply add `--gen [numbers]` at the end, for example:
 
 ```sh
-$HOME/.pokemon-icat/pokemon-icat.sh "-g 3 4 5"
+$HOME/.pokemon-icat/pokemon-icat.sh -g 3 4 5
 ```
 
 If you want to show a pokemon in particular, just use the `--pokemon [pokemon]` flag, for example:
 
 ```sh
-$HOME/.pokemon-icat/pokemon-icat.sh "-p charizard"
+$HOME/.pokemon-icat/pokemon-icat.sh -p charizard
 ```

--- a/pokemon-icat.sh
+++ b/pokemon-icat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-output=$(python3 $HOME/.pokemon-icat/pokemon.py $1)
+output=$(python3 $HOME/.pokemon-icat/pokemon.py ${@:1})
 
 echo $output
 

--- a/pokemon.py
+++ b/pokemon.py
@@ -37,8 +37,8 @@ def evaluate_index_from_generation(generation):
     return randint(start, stop) - 1
 
 # TODO: i bet it can be done better, but hey, this script is garbage anyway
-def evaluate_index_from_name(name_target):
-    with open("nameslist.txt") as f:
+def evaluate_index_from_name(home, name_target):
+    with open(home + "/.pokemon-icat/nameslist.txt") as f:
         names = f.read().split("\n")
         
         for idx, name in enumerate(names):
@@ -76,7 +76,7 @@ def main():
             try:
                 name = sys.argv[2]
 
-                index = evaluate_index_from_name(name)
+                index = evaluate_index_from_name(home, name)
 
                 pokemon = linecache.getline(home + "/.pokemon-icat/nameslist.txt", index)[:-1]
                


### PR DESCRIPTION
Fix the problem when trying to display a pokemon from any folder other than .pokemon-icat.
Remove the necessity of double quotes. For example in `"--g 1 2 3"`, You can now use `-g 1 2 3`