### PR TITLE
Fix outputHash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,8 @@ let
         # outputHash = "sha256-bry1YzkB27/nP92EZct2twNiUIxjRbnjK1g9Bcqi+TY=";
         # outputHash = "sha256-1TnfKN8Ij+pbK6vLXdvbV1qud2HfDHeIJQTzTK+jJP0=";
         # outputHash = "sha256-hOWfpeQz0or/2G9VzYnuc6AFHvlsS5NjmQmMOC01jFM=";
-        outputHash = "sha256-tJ7DIF1xzXHAyA2yEbmHJsKAZxhcgo4WjHLygGhpMHQ=";
+        # outputHash = "sha256-tJ7DIF1xzXHAyA2yEbmHJsKAZxhcgo4WjHLygGhpMHQ=";
+        outputHash = "sha256-C4dlaWlUyyQu8i2d1olXnCiU0gf4iKjdfvjsozw7Il4=";
 
         # src = ./.;
             src = pkgs.lib.fileset.toSource {


### PR DESCRIPTION
This PR fixes a build failure caused by a SHA256 hash mismatch for the `pokemon-icons` dependency.

The upstream source for the icons (`msikma/pokesprite`) appears to have been updated, causing the downloaded file to have a new hash.

The build currently fails with the following error:

error: hash mismatch in fixed-output derivation '/nix/store/452zm401kwhjz1gm6q7v228ggpxil00z-pokemon-icons-1.2.0.drv':
specified: sha256-tJ7DIF1xzXHAyA2yEbmHJsKAZxhcgo4WjHLygGhpMHQ=
got:     sha256-C4dlaWlUyyQu8i2d1olXnCiU0gf4iKjdfvjsozw7Il4=

## Changes

- Updated the `sha256` hash in `default.nix` to the new, correct value reported by the build.

This change allows the package to be built successfully again.
